### PR TITLE
Fix/sc internal naming

### DIFF
--- a/src/tlp_lib/smartcontracts/EthereumSC.py
+++ b/src/tlp_lib/smartcontracts/EthereumSC.py
@@ -19,11 +19,9 @@ class EthereumSC:
         self._initiate_network(web3)
         print("Network initiated")
         self.account = account
-        print("Account initiated")
-        self.contract = None
-        self.contract_path = contract_path
 
         self._contract = None
+        self._contract_path = contract_path
 
     # Public Properties #
 
@@ -84,7 +82,10 @@ class EthereumSC:
 
     def load_contract(self, contract_address):
         (abi, _) = self._compile_contract()
-        self.contract = self.web3.eth.contract(address=contract_address, abi=abi)
+        self._contract = self.web3.eth.contract(address=contract_address, abi=abi)
+
+    def switch_to_account(self, account_index):
+        self.account = self.web3.eth.accounts[account_index]
 
     def add_solution(self, solution, witness):
         if not self._has_succeeded(self._contract.functions.addSolution(solution, witness)):


### PR DESCRIPTION
**Fixed the internal naming issue in `SoliditySC`:**

1. `contract` -> `_contract` as is internal
2. Changed the setter for `contract` to prevent overwriting the previous value as it is unnecessary as well as messes up the compile time checker  
3. `contract_path` -> `_ contract_path`
4. Explicitly moved `account` to public properties as it is accessed externally 